### PR TITLE
Tweak the startup as suggested by Parv.

### DIFF
--- a/stcamera_launch/launch/stcamera_launch.py
+++ b/stcamera_launch/launch/stcamera_launch.py
@@ -78,7 +78,7 @@ def generate_launch_description():
                 "topic_name":"image_raw",
                 "datatype": "image",
                 "main_node_name": "st_camera_lifecycle_node",
-                "startup_time":20
+                "startup_time":200
                 }]  # Parameters
     )
 


### PR DESCRIPTION
The multispectral camera tends to fail to start. Parv suggested making the following change. It seems to work on the robot. Tested on Spot2.