### PR TITLE
Load config

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Examples:
 * **camera_to_connect: ["all"]**: All detected cameras are used.
 * **camera_to_connect: ["00:11:1c:f6:yy:xx","STC-MCS510U3V(00XXYY0)"]**: Only GigEVision camera with MAC address "00:11:1c:f6:yy:xx" and USB3 Vision camera of which model is "STC-MCS510U3V", with serial number "00XXYY0" will be used.
 * **camera_to_connect: ["14210003XXYY"]**: A camera with ID "14210003 XXYY" will be used.
+ 
+* **persistance_file** : Specify the GenAPI persistance file to use for camera configuration. This should contain the full path to the file.
 
 ### 3.2. Camera Namespace
 StCameraNode declares a topic and service for each camera. Each camera's namespace used to access individual camera topics and services is automatically generated using the following rules:

--- a/stcamera_components/include/impl/stcamera_interface_impl.hpp
+++ b/stcamera_components/include/impl/stcamera_interface_impl.hpp
@@ -39,6 +39,7 @@
 
 #include <map>
 #include <sstream>
+#include <fstream>
 #include "../stcamera_interface.hpp"
 
 #include <StApi_TL.h>
@@ -172,6 +173,8 @@ namespace stcamera
        * \param[in] camera_namespace The namespace for the device.
        * \param[in] param Pointer to the StParameter class instance.
        * \param[in] queue_size Used for initializing publisher (Maximum number 
+       * \param[in] use_persistance_file Whether a GenApi persistance file should be loaded
+       * \param[in] persistance_file Filename of a GenApi persistance file to load if requested
        *            of outgoing messages to be queued for delivery to 
        *            subscribers). Default is set to #STCAMERA_QUEUE_SIZE 
        */
@@ -180,7 +183,10 @@ namespace stcamera
                         const std::string &camera_namespace, 
                         StParameter *param,
                         rclcpp::Clock &clock,
-                        uint32_t queue_size = STCAMERA_QUEUE_SIZE);
+                        bool use_persistance_file = false,
+                        std::string persistance_file = "",
+                        uint32_t queue_size = STCAMERA_QUEUE_SIZE
+                        );
 
       /** Destructor.
        *
@@ -597,6 +603,11 @@ namespace stcamera
        * to image subscribers upon publishing acquired images. 
        */  
       void initializeCameraInfo();
+
+      /** Load a GenApi persistance file and configure the camera based on it
+       * \param[in] persistance_file The filename of the persistance file
+       */
+      void loadPersistanceData(const std::string persistance_file);
 
       /** A helper function to obtain the GenICam node for a given module name.
        * \param[in] genicam_module Name of the module: System, Interface,

--- a/stcamera_components/include/impl/stcamera_interface_impl.hpp
+++ b/stcamera_components/include/impl/stcamera_interface_impl.hpp
@@ -186,7 +186,7 @@ namespace stcamera
                         StParameter *param,
                         rclcpp::Clock &clock,
                         bool use_persistance_file = false,
-                        std::string persistance_file = "",
+                        const std::string &persistance_file = "",
                         uint32_t queue_size = STCAMERA_QUEUE_SIZE
                         );
 

--- a/stcamera_components/include/impl/stcamera_interface_impl.hpp
+++ b/stcamera_components/include/impl/stcamera_interface_impl.hpp
@@ -174,10 +174,10 @@ namespace stcamera
        * \param[in] camera_namespace The namespace for the device.
        * \param[in] param Pointer to the StParameter class instance.
        * \param[in] queue_size Used for initializing publisher (Maximum number 
-       * \param[in] use_persistance_file Whether a GenApi persistance file should be loaded
-       * \param[in] persistance_file Filename of a GenApi persistance file to load if requested
        *            of outgoing messages to be queued for delivery to 
        *            subscribers). Default is set to #STCAMERA_QUEUE_SIZE 
+       * \param[in] use_persistance_file Whether a GenApi persistance file should be loaded
+       * \param[in] persistance_file Filename of a GenApi persistance file to load if requested
        */
       StCameraInterfaceImpl(StApi::IStDeviceReleasable *dev,
                         rclcpp::Node *nh_parent, 

--- a/stcamera_components/include/impl/stcamera_node_impl.hpp
+++ b/stcamera_components/include/impl/stcamera_node_impl.hpp
@@ -68,10 +68,7 @@ namespace stcamera
        *            False otherwise.
        */
       bool initializeCamera(StApi::IStInterface *p_iface,
-                            const StApi::IStDeviceInfo *p_devinfo,
-                            bool use_persistance_file,
-                            std::string persistance_file
-                            );
+                            const StApi::IStDeviceInfo *p_devinfo);
 
       /** ROS service callback for obtaining list of all detected devices
        * including the disallowed camera to connect.

--- a/stcamera_components/include/impl/stcamera_node_impl.hpp
+++ b/stcamera_components/include/impl/stcamera_node_impl.hpp
@@ -100,6 +100,12 @@ namespace stcamera
           std::shared_ptr<stcamera_msgs::srv::GetModuleList_Response> res);
           
       void initSystemsAndInterfaces();
+
+      void setPersistanceFile(
+          bool i_use_persistance_file = false,
+          std::string i_persistance_file = ""
+          );
+
     protected:
       const std::string &getTextForMsg() const {return(stcamera_node_text_);}
       rclcpp::Logger get_logger()
@@ -127,6 +133,9 @@ namespace stcamera
       StCameraNode *p_stcamera_node_;
       
       const std::string stcamera_node_text_;
+
+      bool use_persistance_file = false;
+      std::string persistance_file = "";
 
     private:
 

--- a/stcamera_components/include/impl/stcamera_node_impl.hpp
+++ b/stcamera_components/include/impl/stcamera_node_impl.hpp
@@ -68,7 +68,10 @@ namespace stcamera
        *            False otherwise.
        */
       bool initializeCamera(StApi::IStInterface *p_iface,
-                            const StApi::IStDeviceInfo *p_devinfo);
+                            const StApi::IStDeviceInfo *p_devinfo,
+                            bool use_persistance_file,
+                            std::string persistance_file
+                            );
 
       /** ROS service callback for obtaining list of all detected devices
        * including the disallowed camera to connect.

--- a/stcamera_components/include/stparameter.hpp
+++ b/stcamera_components/include/stparameter.hpp
@@ -118,6 +118,8 @@ namespace stcamera
        * word 'all' if specified.
        */
       std::vector<std::string> vec_camera_to_connect_;
+      bool use_persistance_file_ = false;
+      std::string persistance_file_ = "";
   };
 }
 #endif

--- a/stcamera_components/include/stparameter.hpp
+++ b/stcamera_components/include/stparameter.hpp
@@ -112,14 +112,15 @@ namespace stcamera
        */
       rclcpp::Logger::Level getLoggerLevel(const rclcpp::Node *nh) const;
 
+      bool use_persistance_file_ = false;
+      std::string persistance_file_ = "";
+
     protected:
 
       /** Store the list of allowed camera to connect, including special key-
        * word 'all' if specified.
        */
       std::vector<std::string> vec_camera_to_connect_;
-      bool use_persistance_file_ = false;
-      std::string persistance_file_ = "";
   };
 }
 #endif

--- a/stcamera_components/src/stcamera_interface_impl.cpp
+++ b/stcamera_components/src/stcamera_interface_impl.cpp
@@ -2309,7 +2309,7 @@ namespace stcamera
     GenApi::CFeatureBag cfbag;
     std::ifstream fstr(persistance_file.c_str());
     if (!fstr.good()){
-      std::cerr << "Faile to open persistance file:" << persistance_file << std::endl;
+      std::cerr << "Failed to open persistance file:" << persistance_file << std::endl;
       return;
     }
     fstr >> cfbag;

--- a/stcamera_components/src/stcamera_interface_impl.cpp
+++ b/stcamera_components/src/stcamera_interface_impl.cpp
@@ -48,7 +48,7 @@ namespace stcamera
       StParameter *param,
       rclcpp::Clock &clock,
       bool use_persistance_file,
-      std::string persistance_file,
+      const std::string &persistance_file,
       uint32_t queue_size
       ):
     StCameraInterface(parent_nh, camera_namespace, param, clock),

--- a/stcamera_components/src/stcamera_interface_impl.cpp
+++ b/stcamera_components/src/stcamera_interface_impl.cpp
@@ -2312,7 +2312,7 @@ namespace stcamera
     GenApi::CFeatureBag cfbag;
     std::ifstream fstr(persistance_file.c_str());
     if (!fstr.good()){
-      std::cerr << "Failed to open persistance file:" << persistance_file << std::endl;
+      std::cerr << "Failed to open persistance file :" << persistance_file << std::endl;
       return;
     }
     fstr >> cfbag;

--- a/stcamera_components/src/stcamera_interface_impl.cpp
+++ b/stcamera_components/src/stcamera_interface_impl.cpp
@@ -46,7 +46,10 @@ namespace stcamera
       const std::string &camera_namespace, 
       StParameter *param,
       rclcpp::Clock &clock,
-      uint32_t queue_size):
+      bool use_persistance_file,
+      std::string persistance_file,
+      uint32_t queue_size
+      ):
     StCameraInterface(parent_nh, camera_namespace, param, clock),
     tl_dev_(dev),
     camera_info_manager_(nh_.get(), camera_namespace),
@@ -75,6 +78,10 @@ namespace stcamera
     map_msg_event_.insert(std::make_pair(default_event, def_event_));
 
     initDeviceAndDataStream();
+
+    if (use_persistance_file){
+      loadPersistanceData(persistance_file);
+    }
 
     // register event callback for GenTL modules Interface, and System
     ist_registered_callback_interface_ = StApi::RegisterCallback(tl_dev_->GetIStInterface(), *this,
@@ -2296,6 +2303,18 @@ namespace stcamera
     catch(...)
     {
     }
+  }
+
+  void StCameraInterfaceImpl::loadPersistanceData(const std::string persistance_file){
+    GenApi::CFeatureBag cfbag;
+    std::ifstream fstr(persistance_file.c_str());
+    if (!fstr.good()){
+      std::cerr << "Faile to open persistance file:" << persistance_file << std::endl;
+      return;
+    }
+    fstr >> cfbag;
+    GenApi::CNodeMapPtr mp = tl_dev_->GetRemoteIStPort()->GetINodeMap();
+    cfbag.LoadFromBag(mp);
   }
 
   GenApi::INodeMap *StCameraInterfaceImpl::getNodeMap(const std::string &genicam_module)

--- a/stcamera_components/src/stcamera_node.cpp
+++ b/stcamera_components/src/stcamera_node.cpp
@@ -59,7 +59,7 @@ namespace stcamera
   void StCameraNode::init()
   {
     st_camera_node_impl_->initSystemsAndInterfaces();
-    RCLCPP_INFO(get_logger(),"stcamera_node.cpp: Setting persistance file to %s", param_.persistance_file_.c_str());
+    //RCLCPP_INFO(get_logger(),"stcamera_node.cpp: Setting persistance file to %s", param_.persistance_file_.c_str());
     st_camera_node_impl_->setPersistanceFile(param_.use_persistance_file_, param_.persistance_file_);
     initPublishers();
     initServices();

--- a/stcamera_components/src/stcamera_node.cpp
+++ b/stcamera_components/src/stcamera_node.cpp
@@ -47,6 +47,9 @@ namespace stcamera
     get_logger().set_level(logger_level);
     RCLCPP_INFO(get_logger(), "Setting severity threshold to %d", (int)logger_level);
 
+    use_persistance_file = i_use_persistance_file;
+    persistance_file = i_persistance_file;
+
     init();
   }
 

--- a/stcamera_components/src/stcamera_node.cpp
+++ b/stcamera_components/src/stcamera_node.cpp
@@ -47,7 +47,6 @@ namespace stcamera
     get_logger().set_level(logger_level);
     RCLCPP_INFO(get_logger(), "Setting severity threshold to %d", (int)logger_level);
 
-    st_camera_node_impl_->setPersistanceFile(param_.use_persistance_file_, param_.persistance_file_);
 
     init();
   }
@@ -60,6 +59,8 @@ namespace stcamera
   void StCameraNode::init()
   {
     st_camera_node_impl_->initSystemsAndInterfaces();
+    RCLCPP_INFO(get_logger(),"stcamera_node.cpp: Setting persistance file to %s", param_.persistance_file_.c_str());
+    st_camera_node_impl_->setPersistanceFile(param_.use_persistance_file_, param_.persistance_file_);
     initPublishers();
     initServices();
     timer_ = create_wall_timer(1s, std::bind(&StCameraNodeImpl::DetectingAndOpenningDevices, st_camera_node_impl_));

--- a/stcamera_components/src/stcamera_node.cpp
+++ b/stcamera_components/src/stcamera_node.cpp
@@ -47,8 +47,7 @@ namespace stcamera
     get_logger().set_level(logger_level);
     RCLCPP_INFO(get_logger(), "Setting severity threshold to %d", (int)logger_level);
 
-    use_persistance_file = i_use_persistance_file;
-    persistance_file = i_persistance_file;
+    st_camera_node_impl_->setPersistanceFile(param_.use_persistance_file_, param_.persistance_file_);
 
     init();
   }

--- a/stcamera_components/src/stcamera_node_impl.cpp
+++ b/stcamera_components/src/stcamera_node_impl.cpp
@@ -208,10 +208,7 @@ namespace stcamera
 
   }
   bool StCameraNodeImpl::initializeCamera(StApi::IStInterface *p_iface,
-      const StApi::IStDeviceInfo *p_devinfo,
-      bool use_persistance_file,
-      std::string persistance_file
-      )
+      const StApi::IStDeviceInfo *p_devinfo)
   {
     if (p_iface == nullptr || p_devinfo == nullptr)
     {
@@ -271,9 +268,7 @@ namespace stcamera
           GenTL::DEVICE_ACCESS_CONTROL);
 
       StCameraInterface *pcif = new StCameraInterfaceImpl(
-          dev, p_stcamera_node_, key, &p_stcamera_node_->param_, clock_,
-          use_persistance_file, persistance_file
-          );
+          dev, p_stcamera_node_, key, &p_stcamera_node_->param_, clock_);
       map_camera_[key] = pcif;
 
       // store and publish connection msg

--- a/stcamera_components/src/stcamera_node_impl.cpp
+++ b/stcamera_components/src/stcamera_node_impl.cpp
@@ -208,7 +208,10 @@ namespace stcamera
 
   }
   bool StCameraNodeImpl::initializeCamera(StApi::IStInterface *p_iface,
-      const StApi::IStDeviceInfo *p_devinfo)
+      const StApi::IStDeviceInfo *p_devinfo,
+      bool use_persistance_file,
+      std::string persistance_file
+      )
   {
     if (p_iface == nullptr || p_devinfo == nullptr)
     {
@@ -268,7 +271,9 @@ namespace stcamera
           GenTL::DEVICE_ACCESS_CONTROL);
 
       StCameraInterface *pcif = new StCameraInterfaceImpl(
-          dev, p_stcamera_node_, key, &p_stcamera_node_->param_, clock_);
+          dev, p_stcamera_node_, key, &p_stcamera_node_->param_, clock_,
+          use_persistance_file, persistance_file
+          );
       map_camera_[key] = pcif;
 
       // store and publish connection msg

--- a/stcamera_components/src/stcamera_node_impl.cpp
+++ b/stcamera_components/src/stcamera_node_impl.cpp
@@ -213,6 +213,7 @@ namespace stcamera
       ){
     use_persistance_file = i_use_persistance_file;
     if (use_persistance_file){
+      RCLCPP_INFO(p_stcamera_node_->get_logger(),"stcamera_node_impl.cpp: Setting persistance file to %s", persistance_file.c_str());
       persistance_file = i_persistance_file;
     }
   }

--- a/stcamera_components/src/stcamera_node_impl.cpp
+++ b/stcamera_components/src/stcamera_node_impl.cpp
@@ -207,6 +207,16 @@ namespace stcamera
     }
 
   }
+  void StCameraNodeImpl::setPersistanceFile(
+      bool i_use_persistance_file,
+      std::string i_persistance_file
+      ){
+    use_persistance_file = i_use_persistance_file;
+    if (use_persistance_file){
+      persistance_file = i_persistance_file;
+    }
+  }
+
   bool StCameraNodeImpl::initializeCamera(StApi::IStInterface *p_iface,
       const StApi::IStDeviceInfo *p_devinfo)
   {
@@ -268,7 +278,9 @@ namespace stcamera
           GenTL::DEVICE_ACCESS_CONTROL);
 
       StCameraInterface *pcif = new StCameraInterfaceImpl(
-          dev, p_stcamera_node_, key, &p_stcamera_node_->param_, clock_);
+          dev, p_stcamera_node_, key, &p_stcamera_node_->param_, clock_,
+          use_persistance_file, persistance_file
+          );
       map_camera_[key] = pcif;
 
       // store and publish connection msg

--- a/stcamera_components/src/stcamera_node_impl.cpp
+++ b/stcamera_components/src/stcamera_node_impl.cpp
@@ -213,7 +213,7 @@ namespace stcamera
       ){
     use_persistance_file = i_use_persistance_file;
     if (use_persistance_file){
-      RCLCPP_INFO(p_stcamera_node_->get_logger(),"stcamera_node_impl.cpp: Setting persistance file to %s", persistance_file.c_str());
+      RCLCPP_INFO(p_stcamera_node_->get_logger(),"stcamera_node_impl.cpp: Setting persistance file to %s", i_persistance_file.c_str());
       persistance_file = i_persistance_file;
     }
   }

--- a/stcamera_components/src/stparameter.cpp
+++ b/stcamera_components/src/stparameter.cpp
@@ -68,16 +68,14 @@ namespace stcamera
       camera_to_connect.push_back(device_id);
     }
 
-    if (nh->has_parameter("use_persistance_file"))
-    {
-      nh->get_parameter("use_persistance_file", use_persistance_file_);
 
-      if (use_persistance_file_){
-        if (nh->has_parameter("persistance_file"))
-        {
-          nh->get_parameter("persistance_file", persistance_file_);
-        }
-      }
+    if (nh->has_parameter("persistance_file"))
+    {
+      use_persistance_file_ = true;
+      nh->get_parameter("persistance_file", persistance_file_);
+    }
+    else {
+      use_persistance_file_ = false;
     }
   }
 

--- a/stcamera_components/src/stparameter.cpp
+++ b/stcamera_components/src/stparameter.cpp
@@ -67,6 +67,18 @@ namespace stcamera
       // fill in the return arguments
       camera_to_connect.push_back(device_id);
     }
+
+    if (nh->has_parameter("use_persistance_file"))
+    {
+      nh->get_parameter("use_persistance_file", use_persistance_file_);
+
+      if (use_persistance_file_){
+        if (nh->has_parameter("persistance_file"))
+        {
+          nh->get_parameter("persistance_file", persistance_file_);
+        }
+      }
+    }
   }
 
   bool StParameter::connectFirstCameraOnly() const

--- a/stcamera_components/src/stparameter.cpp
+++ b/stcamera_components/src/stparameter.cpp
@@ -74,7 +74,7 @@ namespace stcamera
     if (nh->has_parameter("persistance_file"))
     {
       nh->get_parameter("persistance_file", persistance_file_);
-      RCLCPP_INFO(nh->get_logger(),"stparameter.cpp: Setting persistance file to %s", persistance_file_.c_str());
+      //RCLCPP_INFO(nh->get_logger(),"stparameter.cpp: Setting persistance file to %s", persistance_file_.c_str());
       if (persistance_file_ != ""){
         use_persistance_file_ = true;
       }

--- a/stcamera_components/src/stparameter.cpp
+++ b/stcamera_components/src/stparameter.cpp
@@ -69,14 +69,18 @@ namespace stcamera
     }
 
 
+    RCLCPP_INFO(nh->get_logger(),"stparameter.cpp: Will attempt to retrieve persistance file");
+    use_persistance_file_ = false;
     if (nh->has_parameter("persistance_file"))
     {
-      use_persistance_file_ = true;
       nh->get_parameter("persistance_file", persistance_file_);
+      RCLCPP_INFO(nh->get_logger(),"stparameter.cpp: Setting persistance file to %s", persistance_file_.c_str());
+      if (persistance_file_ != ""){
+        use_persistance_file_ = true;
+      }
     }
-    else {
-      use_persistance_file_ = false;
-    }
+    if (!use_persistance_file_)
+      RCLCPP_INFO(nh->get_logger(),"stparameter.cpp: No perisistance file provided");
   }
 
   bool StParameter::connectFirstCameraOnly() const

--- a/stcamera_launch/launch/stcamera_launch.py
+++ b/stcamera_launch/launch/stcamera_launch.py
@@ -51,6 +51,7 @@ def generate_launch_description():
         'tf_frame',
         default_value=default_tf_frame,
         description='Camera TF frame to be declared in image message headers. Namespaced using the "namespace_value" parameter'
+    )
 
     declare_persistance_file_cmd = DeclareLaunchArgument(
         'persistance_file',
@@ -84,7 +85,7 @@ def generate_launch_description():
             {
             "tf_frame": tf_frame,
             "node_name": node_name,
-            "robot_name": robot_name
+            "robot_name": robot_name,
             "persistance_file": persistance_file
             }
         ]

--- a/stcamera_launch/launch/stcamera_launch.py
+++ b/stcamera_launch/launch/stcamera_launch.py
@@ -100,6 +100,6 @@ def generate_launch_description():
     ld.add_action(declare_persistance_file_cmd)
 
     ld.add_action(stcamera_node)
-    #ld.add_action(monitor_node)
+    ld.add_action(monitor_node)
 
     return ld

--- a/stcamera_launch/launch/stcamera_launch.py
+++ b/stcamera_launch/launch/stcamera_launch.py
@@ -46,6 +46,7 @@ def generate_launch_description():
     )
     declare_persistance_file_cmd = DeclareLaunchArgument(
         'persistance_file',
+        default_value='',
         description='GenApi persistance file of the camera to use'
     )
 
@@ -69,7 +70,10 @@ def generate_launch_description():
         emulate_tty=True,
         prefix=launch_prefix,
         parameters=[
-            config_file
+            config_file,
+            {
+            "persistance_file": persistance_file
+            }
         ]
     )
 
@@ -96,6 +100,6 @@ def generate_launch_description():
     ld.add_action(declare_persistance_file_cmd)
 
     ld.add_action(stcamera_node)
-    ld.add_action(monitor_node)
+    #ld.add_action(monitor_node)
 
     return ld

--- a/stcamera_launch/launch/stcamera_launch.py
+++ b/stcamera_launch/launch/stcamera_launch.py
@@ -26,6 +26,7 @@ def generate_launch_description():
     config_file = LaunchConfiguration('config_file')
     namespace_value = LaunchConfiguration('namespace_value')
     node_name = LaunchConfiguration('node_name')
+    persistance_file = LaunchConfiguration('persistance_file')
 
     # launch arguments
     declare_config_file_cmd = DeclareLaunchArgument(
@@ -42,6 +43,10 @@ def generate_launch_description():
         'node_name',
         default_value='multispectral',
         description='Name of the node.'
+    )
+    declare_persistance_file_cmd = DeclareLaunchArgument(
+        'persistance_file',
+        description='GenApi persistance file of the camera to use'
     )
 
     # log format
@@ -88,6 +93,7 @@ def generate_launch_description():
     ld.add_action(declare_config_file_cmd)
     ld.add_action(declare_namespace_value_cmd)
     ld.add_action(declare_node_name_cmd)
+    ld.add_action(declare_persistance_file_cmd)
 
     ld.add_action(stcamera_node)
     ld.add_action(monitor_node)


### PR DESCRIPTION
Passing filename of a GenAPI camera config file (e.g. `"${HOME}/airlab_ws/config/multispectral_camera/Sunny_Day_mono8_fps-30_Gain-fixed-30_Exposure-time-auto_1024x1024.cfg"`) into the `persistance_file` parameter of `stcamera_launch.py` now allows us to set the camera settings according to e.g. day vs. night.
Apparently, this was done with some Windows GUI program before.